### PR TITLE
Fix date in scrape workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get current date
         id: date        
-        run: echo "{date}=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
As can be seen in https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter  the variable name should be set without `{`.
fixes https://github.com/theDavidBarton/koronavirus.gov.hu-scraper/issues/653